### PR TITLE
Refactor database migrations for MySQL and PostgreSQL

### DIFF
--- a/src/platform/mix.database/Migrations/Cms/MySql/20250609060203_RefactorMixDb.cs
+++ b/src/platform/mix.database/Migrations/Cms/MySql/20250609060203_RefactorMixDb.cs
@@ -1,11 +1,10 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Metadata;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
 namespace Mix.Database.Migrations.Cms.MySql
 {
+    /// <inheritdoc />
     /// <inheritdoc />
     public partial class RefactorMixDb : Migration
     {
@@ -98,6 +97,11 @@ namespace Mix.Database.Migrations.Cms.MySql
                 name: "mix_database_name",
                 table: "mix_theme",
                 newName: "mix_db_table_name");
+
+            migrationBuilder.RenameColumn(
+                name: "mix_database_id",
+                table: "mix_db_column",
+                newName: "mix_db_table_id");
         }
 
         /// <inheritdoc />

--- a/src/platform/mix.database/Migrations/Cms/Postgres/20250130044034_Init.Designer.cs
+++ b/src/platform/mix.database/Migrations/Cms/Postgres/20250130044034_Init.Designer.cs
@@ -93,7 +93,7 @@ namespace Mix.Database.Migrations.Cms.Postgres
                     .HasColumnType("timestamp with time zone")
                     .HasColumnName("last_modified");
 
-                b.Property<string>("MixDbTableName")
+                b.Property<string>("MixDatabaseName")
                     .HasColumnType("varchar(250)")
                     .HasColumnName("mix_database_name")
                     .HasAnnotation("MySql:CharSet", "utf8");
@@ -488,7 +488,7 @@ namespace Mix.Database.Migrations.Cms.Postgres
                 b.ToTable("mix_culture", (string)null);
             });
 
-            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbTable", b =>
+            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDatabase", b =>
             {
                 b.Property<int>("Id")
                     .ValueGeneratedOnAdd()
@@ -536,9 +536,9 @@ namespace Mix.Database.Migrations.Cms.Postgres
                     .HasColumnType("timestamp with time zone")
                     .HasColumnName("last_modified");
 
-                b.Property<int?>("MixDbTableId")
+                b.Property<int?>("MixDatabaseContextId")
                     .HasColumnType("integer")
-                    .HasColumnName("mix_database_id");
+                    .HasColumnName("mix_database_context_id");
 
                 b.Property<int>("TenantId")
                     .HasColumnType("int")
@@ -593,7 +593,7 @@ namespace Mix.Database.Migrations.Cms.Postgres
                 b.ToTable("mix_database", (string)null);
             });
 
-            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbTableRelationship", b =>
+            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDatabaseAssociation", b =>
             {
                 b.Property<Guid>("Id")
                     .ValueGeneratedOnAdd()
@@ -668,7 +668,7 @@ namespace Mix.Database.Migrations.Cms.Postgres
                 b.ToTable("mix_database_association", (string)null);
             });
 
-            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbColumn", b =>
+            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDatabaseColumn", b =>
             {
                 b.Property<int>("Id")
                     .ValueGeneratedOnAdd()
@@ -716,11 +716,11 @@ namespace Mix.Database.Migrations.Cms.Postgres
                     .HasColumnType("timestamp with time zone")
                     .HasColumnName("last_modified");
 
-                b.Property<int>("MixDbTableId")
+                b.Property<int>("MixDatabaseId")
                     .HasColumnType("int")
                     .HasColumnName("mix_database_id");
 
-                b.Property<string>("MixDbTableName")
+                b.Property<string>("MixDatabaseName")
                     .IsRequired()
                     .HasColumnType("varchar(250)")
                     .HasColumnName("mix_database_name")
@@ -755,12 +755,12 @@ namespace Mix.Database.Migrations.Cms.Postgres
                 b.HasKey("Id")
                     .HasName("pk_mix_database_column");
 
-                b.HasIndex("MixDbTableId");
+                b.HasIndex("MixDatabaseId");
 
                 b.ToTable("mix_database_column", (string)null);
             });
 
-            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbDatabase", b =>
+            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDatabaseContext", b =>
             {
                 b.Property<int>("Id")
                     .ValueGeneratedOnAdd()
@@ -861,7 +861,7 @@ namespace Mix.Database.Migrations.Cms.Postgres
                 b.ToTable("mix_database_context", (string)null);
             });
 
-            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbTableRelationship", b =>
+            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDatabaseRelationship", b =>
             {
                 b.Property<int>("Id")
                     .ValueGeneratedOnAdd()
@@ -1545,7 +1545,7 @@ namespace Mix.Database.Migrations.Cms.Postgres
                     .HasColumnType("int")
                     .HasColumnName("mix_culture_id");
 
-                b.Property<string>("MixDbTableName")
+                b.Property<string>("MixDatabaseName")
                     .HasColumnType("varchar(50)")
                     .HasColumnName("mix_database_name");
 
@@ -2008,7 +2008,7 @@ namespace Mix.Database.Migrations.Cms.Postgres
                     .HasColumnType("int")
                     .HasColumnName("mix_culture_id");
 
-                b.Property<string>("MixDbTableName")
+                b.Property<string>("MixDatabaseName")
                     .HasColumnType("varchar(50)")
                     .HasColumnName("mix_database_name");
 
@@ -2361,7 +2361,7 @@ namespace Mix.Database.Migrations.Cms.Postgres
                     .HasColumnType("int")
                     .HasColumnName("mix_culture_id");
 
-                b.Property<string>("MixDbTableName")
+                b.Property<string>("MixDatabaseName")
                     .HasColumnType("varchar(50)")
                     .HasColumnName("mix_database_name")
                     .HasAnnotation("MySql:CharSet", "utf8");
@@ -2748,7 +2748,7 @@ namespace Mix.Database.Migrations.Cms.Postgres
                     .HasColumnType("timestamp with time zone")
                     .HasColumnName("last_modified");
 
-                b.Property<string>("MixDbTableName")
+                b.Property<string>("MixDatabaseName")
                     .HasColumnType("varchar(50)")
                     .HasColumnName("mix_database_name");
 
@@ -2929,7 +2929,7 @@ namespace Mix.Database.Migrations.Cms.Postgres
                 b.Navigation("Tenant");
             });
 
-            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbTable", b =>
+            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDatabase", b =>
             {
                 b.HasOne("Mix.Database.Entities.Cms.Tenant", "Tenant")
                     .WithMany("MixDatabases")
@@ -2940,18 +2940,18 @@ namespace Mix.Database.Migrations.Cms.Postgres
                 b.Navigation("Tenant");
             });
 
-            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbColumn", b =>
+            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDatabaseColumn", b =>
             {
-                b.HasOne("Mix.Database.Entities.Cms.MixDbTable", "MixDbTable")
+                b.HasOne("Mix.Database.Entities.Cms.MixDatabase", "MixDatabase")
                     .WithMany("MixDatabaseColumns")
-                    .HasForeignKey("MixDbTableId")
+                    .HasForeignKey("MixDatabaseId")
                     .OnDelete(DeleteBehavior.Cascade)
                     .IsRequired();
 
-                b.Navigation("MixDbTable");
+                b.Navigation("MixDatabase");
             });
 
-            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbDatabase", b =>
+            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDatabaseContext", b =>
             {
                 b.HasOne("Mix.Database.Entities.Cms.Tenant", "Tenant")
                     .WithMany()
@@ -2962,15 +2962,15 @@ namespace Mix.Database.Migrations.Cms.Postgres
                 b.Navigation("Tenant");
             });
 
-            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbTableRelationship", b =>
+            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDatabaseRelationship", b =>
             {
-                b.HasOne("Mix.Database.Entities.Cms.MixDbTable", "DestinateDatabase")
+                b.HasOne("Mix.Database.Entities.Cms.MixDatabase", "DestinateDatabase")
                     .WithMany("DestinateRelationships")
                     .HasForeignKey("ChildId")
                     .OnDelete(DeleteBehavior.NoAction)
                     .IsRequired();
 
-                b.HasOne("Mix.Database.Entities.Cms.MixDbTable", "SourceDatabase")
+                b.HasOne("Mix.Database.Entities.Cms.MixDatabase", "SourceDatabase")
                     .WithMany("SourceRelationships")
                     .HasForeignKey("ParentId")
                     .OnDelete(DeleteBehavior.NoAction)
@@ -3191,7 +3191,7 @@ namespace Mix.Database.Migrations.Cms.Postgres
                 b.Navigation("MixConfigurationContents");
             });
 
-            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbTable", b =>
+            modelBuilder.Entity("Mix.Database.Entities.Cms.MixDatabase", b =>
             {
                 b.Navigation("DestinateRelationships");
 

--- a/src/platform/mix.database/Migrations/Cms/Postgres/20250609081723_RefactorMixDb.Designer.cs
+++ b/src/platform/mix.database/Migrations/Cms/Postgres/20250609081723_RefactorMixDb.Designer.cs
@@ -12,7 +12,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Mix.Database.Migrations.Cms.Postgres
 {
     [DbContext(typeof(PostgresqlMixCmsContext))]
-    [Migration("20250609070155_RefactorMixDb")]
+    [Migration("20250609081723_RefactorMixDb")]
     partial class RefactorMixDb
     {
         /// <inheritdoc />
@@ -2932,13 +2932,11 @@ namespace Mix.Database.Migrations.Cms.Postgres
 
             modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbColumn", b =>
                 {
-                    b.HasOne("Mix.Database.Entities.Cms.MixDbTable", "MixDbTable")
+                    b.HasOne("Mix.Database.Entities.Cms.MixDbTable", null)
                         .WithMany("MixDbColumns")
                         .HasForeignKey("MixDbTableId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-
-                    b.Navigation("MixDbTable");
                 });
 
             modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbDatabase", b =>

--- a/src/platform/mix.database/Migrations/Cms/Postgres/20250609081723_RefactorMixDb.cs
+++ b/src/platform/mix.database/Migrations/Cms/Postgres/20250609081723_RefactorMixDb.cs
@@ -97,6 +97,11 @@ namespace Mix.Database.Migrations.Cms.Postgres
                 name: "mix_database_name",
                 table: "mix_theme",
                 newName: "mix_db_table_name");
+
+            migrationBuilder.RenameColumn(
+                name: "mix_database_id",
+                table: "mix_db_column",
+                newName: "mix_db_table_id");
         }
 
         /// <inheritdoc />

--- a/src/platform/mix.database/Migrations/Cms/Postgres/PostgresqlMixCmsContextModelSnapshot.cs
+++ b/src/platform/mix.database/Migrations/Cms/Postgres/PostgresqlMixCmsContextModelSnapshot.cs
@@ -2929,13 +2929,11 @@ namespace Mix.Database.Migrations.Cms.Postgres
 
             modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbColumn", b =>
                 {
-                    b.HasOne("Mix.Database.Entities.Cms.MixDbTable", "MixDbTable")
+                    b.HasOne("Mix.Database.Entities.Cms.MixDbTable", null)
                         .WithMany("MixDbColumns")
                         .HasForeignKey("MixDbTableId")
                         .OnDelete(DeleteBehavior.Cascade)
                         .IsRequired();
-
-                    b.Navigation("MixDbTable");
                 });
 
             modelBuilder.Entity("Mix.Database.Entities.Cms.MixDbDatabase", b =>

--- a/src/platform/mix.database/Migrations/Cms/SqlServer/20250603092754_RefactorMixDb.cs
+++ b/src/platform/mix.database/Migrations/Cms/SqlServer/20250603092754_RefactorMixDb.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 
@@ -98,6 +97,11 @@ namespace Mix.Database.Migrations.Cms.SqlServer
                 name: "mix_database_name",
                 table: "mix_theme",
                 newName: "mix_db_table_name");
+
+            migrationBuilder.RenameColumn(
+                name: "mix_database_id",
+                table: "mix_db_column",
+                newName: "mix_db_table_id");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
This commit refactors the database migration files for both MySQL and PostgreSQL by renaming columns and updating entity references.

In the MySQL migration, the column `mix_database_name` in the `mix_theme` table is renamed to `mix_db_table_name`, and `mix_database_id` in the `mix_db_column` table is renamed to `mix_db_table_id`.

In the PostgreSQL migration, references to `MixDbTable` and `MixDbColumn` are updated to `MixDatabase` and `MixDatabaseColumn`, respectively. The column `mix_database_id` is renamed to `mix_database_context_id`, and various properties are adjusted accordingly.

Additionally, entity relationships are updated to ensure navigation properties correctly reference the new entity names. Migration attributes are also updated to reflect the new migration version numbers, enhancing the clarity and consistency of the database schema.
